### PR TITLE
Updated vector name

### DIFF
--- a/fw/src/serial.c
+++ b/fw/src/serial.c
@@ -97,7 +97,7 @@ int uart_read(int uidx)
 	return c;
 }
 
-ISR(USART_RX_vect)
+ISR(USART0_RX_vect)
 {
 	ubuf[0].inbuf[ubuf[0].in_wr] = UDR0;
 	ubuf[0].in_wr = NEXT_IDX(ubuf[0].in_wr);


### PR DESCRIPTION
Without this change I get this warning
```
src/serial.c:100:5: warning: ‘USART_RX_vect’ appears to be a misspelled signal handler, missing __vector prefix [-Wmisspelled-isr]
 ISR(USART_RX_vect)
```
And nothing works when connected to the Indigo.