### PR TITLE
Ignore other values while waiting for mouse ACK

### DIFF
--- a/fw/src/ps2.c
+++ b/fw/src/ps2.c
@@ -314,12 +314,10 @@ ISR(INT1_vect)
 				}
 				break;
 
-			case 2:		/* expect ACK after enable data reporting command */
+			case 2:		/* expect ACK after enable data reporting command, ignore anything else until we get it */
 				if(value == PS2_ACK) {
 					auxstate = 0xff;
-				} else {
-					auxstate = 0;
-				}
+				} 
 				break;
 
 			default:


### PR DESCRIPTION
Some mice seem to send other values before we get the ACK. This was causing auxstate to be reset and the code was back to auxstate=0, waiting for 0xAA which will never happen. 

This change is to ignore other values and stay in auxstate=2 indefinitely until we get the ACK, which eventually comes. 

This makes the Logitech M-S69 mouse work (and possibly others).

This should not affect mice that were already working, as the else part of this check should not be getting hit if the ACK comes right away, although I haven't tested with other mice.